### PR TITLE
Use org gpg keys for publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,8 @@ jobs:
         id: import_gpg
         uses: paultyng/ghaction-import-gpg@v2.1.0
         env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+          GPG_PRIVATE_KEY: ${{ secrets.TF_REGISTRY_GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.TF_REGISTRY_PASSPHRASE }}
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
We added a gpg key and passphrase to the org so we don't have to create new key pairs for each provider repo we want to publish to the registry. PR updates the current secrets to point to the org secrest